### PR TITLE
redirecting http to https

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   config.action_cable.allowed_request_origins = [ 'https://irl-lewagon.herokuapp.com/', 'https://www.reallife.love' ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Clem, followed the step on the following page https://www.lewagon.com/blog/setting-up-free-ssl-certificate-heroku.

SSL is live on Reallife.love as this is back office config on Heroku and tested.  We still have an issue with enforcing SSL for images which I believe will require some cloudinary config (will look into this once this pull request is live if that is okay with you the warning alert is not horrific).

Changed to have the http requests sent to https.  I was not able to test on my localhost while this is extremely straightforward and I am confident it will work.

Please approve so I have fix Cloudinary asap.  Thanks, Henri